### PR TITLE
fix CVE-2026-25075: eap-ttls: Prevent crash if AVP length header field is invalid

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+strongswan (5.9.13-2deepin1) unstable; urgency=medium
+
+  * fix CVE-2026-25075
+
+ -- lichenggang <lichenggang@uniontech.com>  Tue, 07 Apr 2026 13:22:47 +0800
+
 strongswan (5.9.13-2) unstable; urgency=medium
 
   * d/control: drop build-dep on systemd (Closes: #1060509)

--- a/debian/patches/CVE-2026-25075.patch
+++ b/debian/patches/CVE-2026-25075.patch
@@ -1,0 +1,46 @@
+From d4b3c39776f06948d875614a0eddea9561159f2a Mon Sep 17 00:00:00 2001
+From: Tobias Brunner <tobias@strongswan.org>
+Date: Thu, 5 Mar 2026 12:43:12 +0100
+Subject: [PATCH] eap-ttls: Prevent crash if AVP length header field is invalid
+
+The length field in the AVP header includes the 8 bytes of the header
+itself.  Not checking for that and later subtracting it causes an
+integer underflow that usually triggers a crash when accessing a
+NULL pointer that resulted from the failing chunk_alloc() call because
+of the high value.
+
+The attempted allocations for invalid lengths (0-7) are 0xfffffff8,
+0xfffffffc, or 0x100000000 (0 on 32-bit hosts), so this doesn't result
+in a buffer overflow even if the allocation succeeds.
+
+Fixes: 79f2102cb442 ("implemented server side support for EAP-TTLS")
+Fixes: CVE-2026-25075
+---
+ src/libcharon/plugins/eap_ttls/eap_ttls_avp.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/libcharon/plugins/eap_ttls/eap_ttls_avp.c b/src/libcharon/plugins/eap_ttls/eap_ttls_avp.c
+index 06389f7ca73e..2983bd021ded 100644
+--- a/src/libcharon/plugins/eap_ttls/eap_ttls_avp.c
++++ b/src/libcharon/plugins/eap_ttls/eap_ttls_avp.c
+@@ -119,7 +119,7 @@ METHOD(eap_ttls_avp_t, process, status_t,
+ 		chunk_free(&this->input);
+ 		this->inpos = 0;
+ 
+-		if (!success)
++		if (!success || avp_len < AVP_HEADER_LEN)
+ 		{
+ 			DBG1(DBG_IKE, "received invalid AVP header");
+ 			return FAILED;
+@@ -130,7 +130,7 @@ METHOD(eap_ttls_avp_t, process, status_t,
+ 			return FAILED;
+ 		}
+ 		this->process_header = FALSE;
+-		this->data_len = avp_len - 8;
++		this->data_len = avp_len - AVP_HEADER_LEN;
+ 		this->input = chunk_alloc(this->data_len + (4 - avp_len) % 4);
+ 	}
+ 
+-- 
+2.43.0
+

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -2,3 +2,4 @@
 03_systemd-service.patch
 04_disable-libtls-tests.patch
 dont-load-kernel-libipsec-plugin-by-default.patch
+CVE-2026-25075.patch


### PR DESCRIPTION
修复 CVE-2026-25075：strongSwan EAP-TTLS AVP 解析器整数下溢漏洞。

上游补丁：https://download.strongswan.org/security/CVE-2026-25075/strongswan-4.5.0-6.0.4_eap_ttls_avp_len.patch

在 eap_ttls_avp.c 中添加 AVP 长度字段校验，防止当 AVP header 中的 length 值小于 8 时发生整数下溢，进而导致 chunk_alloc() 失败并引发空指针解引用崩溃。